### PR TITLE
debian/control requires now matches what the startup script has

### DIFF
--- a/debian/generate-control
+++ b/debian/generate-control
@@ -10,7 +10,7 @@ Section: devel
 Version: $v
 Maintainer: Trygve Laugstøl <trygvis@inamo.no>
 Architecture: all
-Depends: openjdk-8-jdk | openjdk-7-jdk
+Depends: openjdk-8-jdk | openjdk-7-jdk | oracle-java8-jdk
 Suggests: openjdk-8-source, openjdk-7-source
 Description: $description
 Replaces: $replaces"

--- a/jetbrains.in
+++ b/jetbrains.in
@@ -3,17 +3,10 @@
 paths="
 /usr/lib/jvm/java-8-oracle
 
+/usr/lib/jvm/java-8-openjdk
+/usr/lib/jvm/java-8-openjdk-amd64
 /usr/lib/jvm/java-7-openjdk
-/usr/lib/jvm/java-7-openjdk-amd64
-/usr/jdk/instances/jdk1.7.0
-
-/usr/jdk/instances/jdk1.6.0
-/usr/lib/jvm/java-6-sun
-/usr/lib/jvm/java-6-openjdk
-/usr/lib/jvm/java-6-openjdk-amd64
-
-/usr/jdk/instances/jdk1.5.0
-/usr/lib/jvm/java-5-sun"
+/usr/lib/jvm/java-7-openjdk-amd64"
 
 if [ -r /etc/default/idea ]
 then


### PR DESCRIPTION
The generated package has had the "Requires" line that required openjdk-8-jdk or openjdk-7-sdk to be installed, but the startup script has been looking for openjdk-6-jdk/openjdk-5-jdk/sun java 5/oracle-java8-jdk as well.

Realigned the script and controls to expect either openjdk-8-jdk, openjdk-7-jdk or oracle-java8-jdk. 

Note: it might be worth expanding the compatibility to simply java-sdk, to support also jdk9 and jdk10.