### PR TITLE
The package names have changed (idea-iu became jetbrains-iiu) but the…

### DIFF
--- a/build-package
+++ b/build-package
@@ -199,11 +199,11 @@ product=$(tr '[:upper:]' '[:lower:]' <<< $product)
 case $product_u in
   IIU)
     real_bin=idea.sh
-    replaces=idea-ic
+    replaces=idea-ic,jetbrains-iic,idea-iu
     ;;
   IIC)
     real_bin=idea.sh
-    replaces=idea-iu
+    replaces=idea-iu,jetbrains-iiu,idea-ic
     ;;
   CL)
     real_bin=clion.sh

--- a/debian/generate-control
+++ b/debian/generate-control
@@ -16,10 +16,10 @@ Description: $description
 Replaces: $replaces"
 
 case "$p" in
-  idea-ic)
-    echo "Conflicts: idea-iu"
+  jetbrains-iic)
+    echo "Conflicts: idea-iu, jetbrains-iiu"
     ;;
-  idea-iu)
-    echo "Conflicts: idea-ic"
+  jetbrains-iiu)
+    echo "Conflicts: idea-ic, jetbrains-iic"
     ;;
 esac


### PR DESCRIPTION
Recent changes renamed the packages from individual names (idea-iu, idea-ic) to a new jetbrains-* format. Unfortunately, the replaces/conflicts have not been updated to match. This change fixes that, and also provides the ability for IIC and IIU packages to replace each other correctly.